### PR TITLE
Rename deprecated subscribeAsync function

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-nats-async "1.2.1"
+(defproject clj-nats-async "1.2.2"
   :description "an async client for NATS, wrapping java-nats"
   :url "https://github.com/employeerepublic/clj-nats-async"
   :license {:name "Apache License, Version 2.0"

--- a/src/clj_nats_async/core.clj
+++ b/src/clj_nats_async/core.clj
@@ -26,7 +26,7 @@
 
 (defn ^:private create-nats-subscription
   [nats subject {:keys [queue] :as opts} stream]
-  (.subscribeAsync
+  (.subscribe
    nats
    subject
    queue


### PR DESCRIPTION
subscribeAsync annotated as deprecated function  [source](https://github.com/nats-io/java-nats/blob/71f4154ef7a3037356f79a3f63fc20602b505c45/src/main/java/io/nats/client/ConnectionImpl.java#L1883)

Using subscribe function instead.